### PR TITLE
feat: Improve node editing UX and recalculate schedule

### DIFF
--- a/src/lib/presentation/components/FlowCanvas.svelte
+++ b/src/lib/presentation/components/FlowCanvas.svelte
@@ -147,6 +147,7 @@
                     isTerminal: n.id === terminalId(),
                     computedHours:
                         n.id === terminalId() ? totalOthers : n.effortHours,
+                    terminalNodeId: terminalId(),
                 },
                 type: "editable",
                 sourcePosition: Position.Right,


### PR DESCRIPTION
This commit introduces two main improvements to the Gantt chart UI:

1.  **Auto-focus on New Nodes**: When a new task node is added by pressing the Tab key, the "Task Name" input field is now automatically focused. This allows you to start typing the task name immediately without an extra click.

2.  **Recalculate Schedule on Edit**: When a node's details are updated (e.g., name or effort hours are changed) and the "OK" button is clicked, the entire project schedule is now recalculated. This ensures that the start and end dates of all tasks are updated automatically based on the new information.