### PR TITLE
Add Japanese and English localization support

### DIFF
--- a/src/lib/presentation/components/EditableNode.svelte
+++ b/src/lib/presentation/components/EditableNode.svelte
@@ -2,8 +2,9 @@
     import type { NodeEntity } from "$lib/domain/entities";
     import { projectStore } from "$lib/presentation/stores/projectStore";
     import { Handle, Position } from "@xyflow/svelte";
-import { get } from "svelte/store";
-import { scheduleBackward } from "$lib/usecases/scheduleBackward";
+    import { get } from "svelte/store";
+    import { scheduleBackward } from "$lib/usecases/scheduleBackward";
+    import { t } from "$lib/presentation/stores/i18n";
 
     // SvelteFlow から渡される props
     let {
@@ -23,6 +24,7 @@ import { scheduleBackward } from "$lib/usecases/scheduleBackward";
     let editing = $state(true);
     let name = $state(data?.name ?? "");
     let hours = $state<number | string>(data?.effortHours ?? 0);
+    let tr = $state(get(t));
 
     let nameInputEl: HTMLInputElement | null = null;
 
@@ -36,6 +38,10 @@ import { scheduleBackward } from "$lib/usecases/scheduleBackward";
         if (editing) {
             nameInputEl?.focus();
         }
+    });
+    $effect(() => {
+        const un = t.subscribe((v) => (tr = v));
+        return () => un?.();
     });
 
     function startEdit(e: MouseEvent) {
@@ -96,15 +102,27 @@ import { scheduleBackward } from "$lib/usecases/scheduleBackward";
     }
 </script>
 
-<div class="node" class:selected on:dblclick={startEdit}>
+<div
+    class="node"
+    class:selected
+    ondblclick={startEdit}
+    role="button"
+    tabindex="0"
+>
     {#if editing && !data?.isTerminal}
-        <div class="editor" on:keydown={onKeyDown} on:click|stopPropagation>
+        <div
+            class="editor"
+            onkeydown={onKeyDown}
+            onclick={(e) => e.stopPropagation()}
+            role="group"
+            tabindex="0"
+        >
             <div>
                 <input
                     bind:this={nameInputEl}
                     class="in"
                     type="text"
-                    placeholder="作業名"
+                    placeholder={tr.taskName}
                     bind:value={name}
                 />
             </div>
@@ -123,10 +141,21 @@ import { scheduleBackward } from "$lib/usecases/scheduleBackward";
                         >Σ {(data?.computedHours ?? 0).toFixed(1)}h</span
                     >
                 {/if}
-                <button class="btn" on:click|stopPropagation={commit}>OK</button
+                <button
+                    class="btn"
+                    onclick={(e) => {
+                        e.stopPropagation();
+                        commit();
+                    }}
+                    >{tr.ok}</button
                 >
-                <button class="btn" on:click|stopPropagation={cancel}
-                    >Cancel</button
+                <button
+                    class="btn"
+                    onclick={(e) => {
+                        e.stopPropagation();
+                        cancel();
+                    }}
+                    >{tr.cancel}</button
                 >
             </div>
         </div>

--- a/src/lib/presentation/stores/i18n.ts
+++ b/src/lib/presentation/stores/i18n.ts
@@ -1,0 +1,43 @@
+import { writable, derived } from 'svelte/store';
+
+export type Locale = 'ja' | 'en';
+export const locale = writable<Locale>('ja');
+
+export const dictionary: Record<Locale, Record<string, string>> = {
+  ja: {
+    align: '整列',
+    schedule: '逆算',
+    criticalChain: 'クリティカルチェーン',
+    save: '保存',
+    load: '読み込み',
+    dueDate: '納期',
+    projectBuffer: 'PB',
+    use50: '50%',
+    newTask: '新規タスク',
+    finalProduct: '最終成果物',
+    ccTitle: 'クリティカルチェーン',
+    totalHours: '合計時間',
+    taskName: '作業名',
+    ok: 'OK',
+    cancel: 'キャンセル'
+  },
+  en: {
+    align: 'Align',
+    schedule: 'Schedule',
+    criticalChain: 'Critical Chain',
+    save: 'Save',
+    load: 'Load',
+    dueDate: 'Due',
+    projectBuffer: 'PB',
+    use50: '50%',
+    newTask: 'New Task',
+    finalProduct: 'Final Product',
+    ccTitle: 'Critical Chain',
+    totalHours: 'Total Hours',
+    taskName: 'Task name',
+    ok: 'OK',
+    cancel: 'Cancel'
+  }
+};
+
+export const t = derived(locale, ($locale) => dictionary[$locale]);

--- a/src/lib/presentation/stores/projectStore.ts
+++ b/src/lib/presentation/stores/projectStore.ts
@@ -1,5 +1,6 @@
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import type { ProjectSnapshot } from '$lib/domain/entities';
+import { t } from './i18n';
 
 export const projectStore = writable<ProjectSnapshot>({
     project: {
@@ -11,7 +12,12 @@ export const projectStore = writable<ProjectSnapshot>({
         hoursPerDay: 8
     },
     nodes: [
-        { id: 'n1', name: '最終成果物', effortHours: 8, position: { x: 0, y: 0 } },
+        {
+            id: 'n1',
+            name: get(t).finalProduct,
+            effortHours: 8,
+            position: { x: 0, y: 0 }
+        },
     ],
     edges: [],
     groups: []


### PR DESCRIPTION
## Summary
- add i18n store with Japanese and English dictionaries
- wire localization into header, node editing, and flow canvas
- allow switching languages between Japanese and English

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68994716a5bc832484ea5135600c4910