### PR TITLE
Align end dates for parallel tasks in same hierarchy

### DIFF
--- a/src/lib/usecases/scheduleBackward.ts
+++ b/src/lib/usecases/scheduleBackward.ts
@@ -9,11 +9,9 @@ export function scheduleBackward(
     terminalNodeId: string
 ): ScheduleResult {
     const nodeMap = new Map(nodes.map(n => [n.id, { ...n }]));
-    const succ = new Map<string, string[]>();
     const pred = new Map<string, string[]>();
 
     edges.forEach(e => {
-        succ.set(e.source, [...(succ.get(e.source) ?? []), e.target]);
         pred.set(e.target, [...(pred.get(e.target) ?? []), e.source]);
     });
 
@@ -21,63 +19,53 @@ export function scheduleBackward(
         (settings.useFiftyPctEstimate ? n.effortHours * settings.shrinkRatio : n.effortHours);
 
     const terminalEnd = new Date(new Date(settings.dueDate).getTime() - settings.projectBufferDays * 24 * 3600 * 1000);
-    const order = reverseTopological(nodes, edges);
 
     const t = nodeMap.get(terminalNodeId);
     if (!t) throw new Error('terminal node not found');
     t.end = toISODate(terminalEnd);
     t.start = toISODate(terminalEnd);
 
-    for (const id of order) {
-        if (id === terminalNodeId) continue;
-        const node = nodeMap.get(id)!;
-        const successors = succ.get(id) ?? [];
-        let minStartOfSucc: Date | undefined;
-        for (const s of successors) {
-            const sNode = nodeMap.get(s)!;
-            if (!sNode.start) continue;
-            const d = new Date(sNode.start);
-            minStartOfSucc = !minStartOfSucc || d < minStartOfSucc ? d : minStartOfSucc;
+    const level = new Map<string, number>();
+    const q: string[] = [terminalNodeId];
+    level.set(terminalNodeId, 0);
+    while (q.length) {
+        const v = q.shift()!;
+        for (const p of pred.get(v) ?? []) {
+            if (!level.has(p)) {
+                level.set(p, (level.get(v) ?? 0) + 1);
+                q.push(p);
+            }
         }
-        const end = minStartOfSucc ?? terminalEnd;
-        const start = new Date(end.getTime() - toWorkingMs(eff(node), settings));
-        node.end = toISODate(end);
-        node.start = toISODate(start);
-        t.start = toISODate(new Date(Math.min(
-            new Date(t.start).getTime(),
-            new Date(node.start).getTime()
-        )));
-        t.end = toISODate(new Date(Math.max(
-            new Date(t.end).getTime(),
-            new Date(node.end).getTime()
-        )));
+    }
+
+    const maxLevel = Math.max(...level.values());
+    for (let l = 1; l <= maxLevel; l++) {
+        const prevNodes = Array.from(level.entries())
+            .filter(([_, lvl]) => lvl === l - 1)
+            .map(([id]) => nodeMap.get(id)!)
+            .filter(n => n.start);
+        let minStartPrev = terminalEnd;
+        for (const n of prevNodes) {
+            const d = new Date(n.start!);
+            if (d < minStartPrev) minStartPrev = d;
+        }
+        for (const [id, lvl] of level.entries()) {
+            if (lvl !== l) continue;
+            const node = nodeMap.get(id)!;
+            const end = minStartPrev;
+            const start = new Date(end.getTime() - toWorkingMs(eff(node), settings));
+            node.end = toISODate(end);
+            node.start = toISODate(start);
+            t.start = toISODate(new Date(Math.min(
+                new Date(t.start).getTime(),
+                start.getTime()
+            )));
+            t.end = toISODate(new Date(Math.max(
+                new Date(t.end).getTime(),
+                end.getTime()
+            )));
+        }
     }
 
     return { nodes: Array.from(nodeMap.values()) };
-}
-
-function reverseTopological(nodes: NodeEntity[], edges: EdgeEntity[]): string[] {
-    const succ = new Map<string, string[]>();
-    const indeg = new Map<string, number>();
-    nodes.forEach(n => indeg.set(n.id, 0));
-    edges.forEach(e => {
-        succ.set(e.source, [...(succ.get(e.source) ?? []), e.target]);
-        indeg.set(e.target, (indeg.get(e.target) ?? 0) + 1);
-    });
-    const q: string[] = nodes.filter(n => (succ.get(n.id) ?? []).length === 0).map(n => n.id);
-    const order: string[] = [];
-    const visited = new Set<string>();
-    while (q.length) {
-        const v = q.pop()!;
-        if (visited.has(v)) continue;
-        visited.add(v);
-        order.push(v);
-        for (const e of edges.filter(e => e.target === v)) {
-            const u = e.source;
-            const remain = (succ.get(u) ?? []).filter(x => x !== v);
-            succ.set(u, remain);
-            if (remain.length === 0) q.push(u);
-        }
-    }
-    return order;
 }


### PR DESCRIPTION
## Summary
- compute node levels and schedule by hierarchy so tasks at the same depth end on the same day

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689951548e2c83249838fd9ca031a77e